### PR TITLE
docs(emoji-key): added missing `business` and `content`

### DIFF
--- a/docs/emoji-key.md
+++ b/docs/emoji-key.md
@@ -13,9 +13,9 @@ Emoji/Type | Represents | Comments
 💬 <br /> `question` | Answering Questions | Answering Questions in Issues, Stack Overflow, Gitter, Slack, etc.
 🐛 <br /> `bug` | Bug reports | links to issues reported by the user on this project
 📝 <br /> `blog` | Blogposts | links to the blogpost
-💼 <br /> N/I* | Business Development | people who execute on the business end
+💼 <br /> `business` | Business Development | people who execute on the business end
 💻 <br /> `code` | Code | links to commits by the user on this project
-🖋 <br /> N/I* | Content | e.g. website copy, blog posts are separate
+🖋 <br /> `content` | Content | e.g. website copy, blog posts are separate
 📖 <br /> `doc` | Documentation | links to commits by the user on this project`, Wiki, or other source of documentation
 🎨 <br /> `design` | Design | links to the logo/iconography/visual design/etc.
 💡 <br /> `examples` | Examples | links to the examples

--- a/docs/emoji-key.md
+++ b/docs/emoji-key.md
@@ -37,8 +37,6 @@ Emoji/Type | Represents | Comments
 📓 <br /> `userTesting` | User Testing | links to user test notes
 📹 <br /> `video` | Videos | links to the video
 
-*N/I: These contribution types are currently not supported by tooling.
-
 ## What's next
 - [Notes for repository maintainers](repository-maintainers)
 - [Automating the process using tools](tooling)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "crowdin-upload": "crowdin --config crowdin.yaml upload sources --auto-update -b master",
     "crowdin-download": "crowdin --config crowdin.yaml download -b master",
     "publish-gh-pages": "cd website && ../node_modules/.bin/docusaurus-publish",
-    "commit": "npx git-cz"
+    "commit": "git-cz"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^2.1.0",


### PR DESCRIPTION
I added the missing types and removed the unneeded `npx` call in the `commit` NPM script.